### PR TITLE
Group plugins by operational system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@
 ## Contents
 
 - [Plugins](#plugins)
+  - [Operational System Exclusives](#operational-system-exclusives)
+    - [Linux](#linux)
+    - [macOS](#macos)
+    - [Windows](#windows)
 - [Boilerplates](#boilerplates)
 
 ## Plugins
 
-- [cerebro-linux-system](https://www.npmjs.com/package/cerebro-linux-system) - Cerebro plugin to automate some Linux system features.
 - [cerebro-stackoverflow](https://www.npmjs.com/package/cerebro-stackoverflow) - Cerebro plugin to find answers to questions on stack overflow.
 - [cerebro-hash](https://www.npmjs.com/package/cerebro-hash) - Cerebro plugin to hash input.
-- [cerebro-osx-eject](https://www.npmjs.com/package/cerebro-osx-eject) - Quickly eject mounted volumes in macOS.
 - [cerebro-salary](https://www.npmjs.com/package/cerebro-salary) - Cerebro plugin for calculating take-home wage in Czech Republic..
-- [cerebro-osx-system](https://www.npmjs.com/package/cerebro-osx-system) - Cerebro plugin to automate some OSx system features.
 - [cerebro-lipsum](https://www.npmjs.com/package/cerebro-lipsum) - Cerebro plugin to generate lorem ipsum text from www.lipsum.com.
 - [cerebro-timezones](https://www.npmjs.com/package/cerebro-timezones) - Cerebro plugin to show time in different time zones.
 - [convert-color](https://www.npmjs.com/package/convert-color) - Convert Hex code to RGB and vice versa.
@@ -36,25 +37,39 @@
 - [cerebro-github](https://www.npmjs.com/package/cerebro-github) - Cerebro plugin to get repo and user information from github.
 - [cerebro-caniuse](https://www.npmjs.com/package/cerebro-caniuse) - Cerebro plugin for quick access to caniuse.com database.
 - [cerebro-clipboard](https://www.npmjs.com/package/cerebro-clipboard) - Cerebro plugin to record and recall list of items on clipboard.
-- [cerebro-osx-contacts](https://www.npmjs.com/package/cerebro-osx-contacts) - Cerebro plugin to search in OSx Contacts.app.
 - [cerebro-devdocs](https://www.npmjs.com/package/cerebro-devdocs) - Cerebro plugin for devdocs.io documentations.
-- [cerebro-osx-define](https://www.npmjs.com/package/cerebro-osx-define) - Cerebro plugin to define entered text in OSx dictionary.
 - [cerebro-vagalume-plugin](https://www.npmjs.com/package/cerebro-vagalume-plugin) - Plugin do app Cerebro para encontrar letras no Vagalume.
 - [cerebro-hex](https://www.npmjs.com/package/cerebro-hex) - A Cerebro plugin for searching hex.pm packages.
 - [cerebro-duck-duck-go](https://www.npmjs.com/package/cerebro-duck-duck-go) - Use Duck Duck Go as your Cerebro App search engine.
 - [cerebro-vaporwave](https://www.npmjs.com/package/cerebro-vaporwave) - Cool text bro but it need more ＶＡＰＯＲＷＡＶＥ.
-- [cerebro-es-everything-plugin](https://www.npmjs.com/package/cerebro-es-everything-plugin) - Cerebro Everything by voidtools interface plugin
 - [cerebro-npm](https://www.npmjs.com/package/cerebro-npm) - A Cerebro plugin for searching NPM packages.
-- [cerebro-windows-system](https://www.npmjs.com/package/cerebro-windows-system) - Cerebro plugin to automate some windows features.
 - [cerebro-mal](https://www.npmjs.com/package/cerebro-mal) - MyAnimeList plugin for Cerebro.
 - [cerebro-reload](https://github.com/lubien/cerebro-reload) - Reload Cerebro using Cerebro.
 - [cerebro-aqi](https://www.npmjs.com/package/cerebro-aqi) - Search for AQI (Air Quality Index) information of cities.
 - [cerebro-mdn](https://github.com/tiagoamaro/cerebro-mdn) - Cerebro's plugin to search terms on MDN (Mozilla Developer Network).
 - [cerebro-rubygems](https://github.com/tiagoamaro/cerebro-rubygems) - Cerebro's plugin to search gems on Rubygems.
 
+### Operational System Exclusives
+
+#### macOS
+
+- [cerebro-osx-contacts](https://www.npmjs.com/package/cerebro-osx-contacts) - Cerebro plugin to search in OSx Contacts.app.
+- [cerebro-osx-define](https://www.npmjs.com/package/cerebro-osx-define) - Cerebro plugin to define entered text in OSx dictionary.
+- [cerebro-osx-eject](https://www.npmjs.com/package/cerebro-osx-eject) - Quickly eject mounted volumes in macOS.
+- [cerebro-osx-system](https://www.npmjs.com/package/cerebro-osx-system) - Cerebro plugin to automate some OSx system features.
+
+#### Windows
+
+- [cerebro-es-everything-plugin](https://www.npmjs.com/package/cerebro-es-everything-plugin) - Cerebro Everything by voidtools interface plugin.
+- [cerebro-windows-system](https://www.npmjs.com/package/cerebro-windows-system) - Cerebro plugin to automate some windows features.
+
+#### Linux
+
+- [cerebro-linux-system](https://www.npmjs.com/package/cerebro-linux-system) - Cerebro plugin to automate some Linux system features.
+
 ## Boilerplates
 
-- [Cerebro Plugin](https://github.com/KELiON/cerebro-plugin) - It is boilerplate to create plugins for Cerebro app 
+- [Cerebro Plugin](https://github.com/KELiON/cerebro-plugin) - It is boilerplate to create plugins for Cerebro app.
 
 ## License
 


### PR DESCRIPTION
Hello @lubien! :)

Following the repository suggestions on creating new categories, I've grouped some plugins by platform.

Since `awesome-cerebro` is going to replace the plugin list at Cerebro's main repository (https://github.com/KELiON/cerebro/issues/205), this PR is replicating the main repository current plugin aggregation.