### PR TITLE
Add cerebro-pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [cerebro-aqi](https://www.npmjs.com/package/cerebro-aqi) - Search for AQI (Air Quality Index) information of cities.
 - [cerebro-mdn](https://github.com/tiagoamaro/cerebro-mdn) - Cerebro's plugin to search terms on MDN (Mozilla Developer Network).
 - [cerebro-rubygems](https://github.com/tiagoamaro/cerebro-rubygems) - Cerebro's plugin to search gems on Rubygems.
+- [cerebro-pass](https://github.com/jsantiagoh/cerebro-pass) - Cerebro's plugin to search and copy passwords from [pass](https://www.passwordstore.org/).
 
 ### Operational System Exclusives
 


### PR DESCRIPTION
Cerebro-pass is a plugin that allows searching and copying passwords from https://www.passwordstore.org/