### PR TITLE
Add plugin cerebro-wolfram-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [cerebro-torrent](https://github.com/wangshub/cerebro-torrent) - Cerebro plugin to search torrent of movies.
 - [cerebro-blockchain](https://github.com/tim-hub/cerebro-blockchain) - A cerebro plugin to get the blockchain states and information.
 - [cerebro-filmaffinity](https://github.com/jnavb/cerebro-filmaffinity) - Cerebro plugin to search movie info from filmaffinity webpage.
+- [cerebro-wolfram-alpha](https://www.npmjs.com/package/cerebro-wolfram-alpha) - Cerebro plugin to use WolframAlpha API.
 
 ### Operational System Exclusives
 


### PR DESCRIPTION
Add  the plugin, cerebro-wolfram-alpha, which allows user to use wolfram alpha API.